### PR TITLE
Bump version to v4.4.2 (patch)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "browser-permissions-helper",
-  "version": "4.4.1",
+  "version": "4.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "browser-permissions-helper",
-      "version": "4.4.1",
+      "version": "4.4.2",
       "license": "MIT",
       "devDependencies": {
         "http-server": "14.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browser-permissions-helper",
-  "version": "4.4.1",
+  "version": "4.4.2",
   "description": "A simple package to check and request browser permissions",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Automated version bump for npm publish. Version v4.4.2 (patch). Opened because main is protected.